### PR TITLE
Atribuindo permissão ao script.sh

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,7 @@ services:
     volumes:
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
       - ./postgres-data:/var/lib/postgresql/data
+      - ./script.sh:/path/to/container/script.sh:rw
     networks:
       - postgres-compose-network
 


### PR DESCRIPTION
Atribuindo permissão de executar o script, isso é necessário para rodar em uma máquina linux. 